### PR TITLE
Add --allow-all option and tweak defaults so deno can be run without configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,24 +45,50 @@ Transfer/sec:    164.50MB
 
 Deno sandboxed in TinyKVM:
 ```sh
-$ ./wrk -c1 -t1 http://127.00.1:8080
-Running 10s test @ http://127.00.1:8080
+$ ./wrk -c1 -t1 http://127.0.0.1:8000
+Running 10s test @ http://127.0.0.1:8000
   1 threads and 1 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    16.42us    3.03us 277.00us   92.06%
-    Req/Sec    60.26k     4.81k   63.15k    91.09%
-  605804 requests in 10.10s, 89.55MB read
-Requests/sec:  59981.22
-Transfer/sec:      8.87MB
+    Latency    15.50us    1.72us 126.00us   93.03%
+    Req/Sec    63.61k     2.35k   65.78k    88.12%
+  638961 requests in 10.10s, 94.45MB read
+Requests/sec:  63264.87
+Transfer/sec:      9.35MB
 
-$ ./wrk -c64 -t64 http://127.00.1:8080
-Running 10s test @ http://127.00.1:8080
+$ ./wrk -c64 -t64 http://127.0.0.1:8000
+Running 10s test @ http://127.0.0.1:8000
   64 threads and 64 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    69.96us   58.90us   5.53ms   97.43%
-    Req/Sec    14.72k     3.48k   37.18k    75.40%
-  9465008 requests in 10.10s, 1.37GB read
-Requests/sec: 937194.37
-Transfer/sec:    138.54MB
+    Latency    68.30us   97.70us  11.34ms   99.04%
+    Req/Sec    15.61k     6.90k   32.44k    77.84%
+  10038128 requests in 10.10s, 1.45GB read
+Requests/sec: 993829.98
+Transfer/sec:    146.91MB
 ```
-Deno in TinyKVM has around ~5us in context switching and safety overhead per request. But has good scaling with forked VMs.
+Deno in TinyKVM has around ~4us in context-switching and safety overhead per request. But has good scaling with forked VMs.
+
+## React benchmark
+
+Rendering a React page we get:
+```sh
+$ ./wrk -c1 -t1 http://127.0.0.1:8000
+Running 10s test @ http://127.0.0.1:8000
+  1 threads and 1 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   533.24us   22.99us   0.91ms   88.97%
+    Req/Sec     1.88k     9.42     1.90k    68.00%
+  18741 requests in 10.00s, 558.53MB read
+Requests/sec:   1874.07
+Transfer/sec:     55.85MB
+
+$ ./wrk -c8 -t8 http://127.0.0.1:8000
+Running 10s test @ http://127.0.0.1:8000
+  8 threads and 8 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   589.57us   39.86us   1.26ms   81.93%
+    Req/Sec     1.70k    60.49     1.81k    55.45%
+  136925 requests in 10.10s, 3.99GB read
+Requests/sec:  13556.71
+Transfer/sec:    404.02MB
+```
+This scales well over many cores, as can be seen above. Producing 13.5k server-rendered pages per second in a sandbox is quite insane.

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,1 @@
+./run.sh -w 250 -e -t 0 -c deno/config.json -- run --allow-all deno/main.ts

--- a/deno/config.json
+++ b/deno/config.json
@@ -1,12 +1,12 @@
 {
 	"filename": "$HOME/github/deno/target/release/deno",
 	//"filename": "$HOME/.deno/bin/deno",
-	"ephemeral": true,
+	"ephemeral": false,
 	"concurrency": 2,
 	"address_space": 66000,
 	"max_memory": 4400,
 	"environment": [
-		"DENO_V8_FLAGS=--single-threaded,--max-old-space-size=64,--max-semi-space-size=64",
+		"DENO_V8_FLAGS=--single-threaded,--max-old-space-size=256,--max-semi-space-size=256",
 		"DENO_DIR=$HOME/.cache/deno",
 		"DENO_NO_UPDATE_CHECK=1"
 	],

--- a/deno/config.json
+++ b/deno/config.json
@@ -2,7 +2,6 @@
 	"filename": "$HOME/github/deno/target/release/deno",
 	//"filename": "$HOME/.deno/bin/deno",
 	"ephemeral": false,
-	"concurrency": 2,
 	"address_space": 66000,
 	"max_memory": 4400,
 	"environment": [

--- a/deno/main.ts
+++ b/deno/main.ts
@@ -3,7 +3,7 @@ import { connect } from "jsr:@db/redis";
 console.log("Hello from Deno inside TinyKVM");
 
 Deno.serve({
-	port: 8080
+	port: 8000
 }, async (req) => {
   const url = new URL(req.url);
   const path = url.pathname;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -99,12 +99,8 @@ Configuration Configuration::FromJsonFile(const std::string& filename)
 		if (config.concurrency == 0) {
 			config.concurrency = std::thread::hardware_concurrency();
 		}
-		// The filename is required
-		if (!json.contains("filename")) {
-			fprintf(stderr, "Missing required field 'filename' in configuration file: %s\n", filename.c_str());
-			throw std::runtime_error("Missing required field 'filename' in configuration file: " + filename);
-		}
-		config.filename = json["filename"].get<std::string>();
+		// The program filename may be specified on command line
+		config.filename = json.value("filename", config.filename);
 		config.filename = apply_dollar_vars(config.filename);
 
 		/* Most of these fields are optional. */

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -206,6 +206,12 @@ Configuration Configuration::FromJsonFile(const std::string& filename)
 			}
 		}
 
+		// TODO: needs config option.
+		char cwd[PATH_MAX];
+		if (getcwd(cwd, sizeof(cwd)) != nullptr) {
+			config.current_working_directory = cwd;
+		}
+
 		// Raise the memory sizes into megabytes
 		config.max_address_space = config.max_address_space * (1ULL << 20);
 		config.max_main_memory = config.max_main_memory * (1ULL << 20);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,7 +2,6 @@
 #include <fstream>
 #include <limits.h>
 #include <nlohmann/json.hpp>
-#include <thread>
 #include <unistd.h>
 
 static std::string apply_dollar_vars(std::string str)
@@ -101,9 +100,6 @@ Configuration Configuration::FromJsonFile(const std::string& filename)
 	// Parse the JSON data into the Configuration object
 	try {
 		config.concurrency = json.value("concurrency", config.concurrency);
-		if (config.concurrency == 0) {
-			config.concurrency = std::thread::hardware_concurrency();
-		}
 		// The program filename may be specified on command line
 		config.filename = json.value("filename", config.filename);
 		config.filename = apply_dollar_vars(config.filename);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,7 +1,9 @@
 #include "config.hpp"
 #include <fstream>
+#include <limits.h>
 #include <nlohmann/json.hpp>
 #include <thread>
+#include <unistd.h>
 
 static std::string apply_dollar_vars(std::string str)
 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -77,20 +77,25 @@ void add_remappings(const nlohmann::json& json, std::vector<T>& remappings,
 Configuration Configuration::FromJsonFile(const std::string& filename)
 {
 	Configuration config;
-	// Load the JSON file and parse it
-	std::ifstream file(filename);
-	if (!file.is_open()) {
-		throw std::runtime_error("Could not open configuration file: " + filename);
-	}
-
 	nlohmann::json json;
-	// Allow comments in the JSON file
-	try {
-		json = json.parse(file, nullptr, false, true);
-	} catch (const nlohmann::json::parse_error& e) {
-		fprintf(stderr, "Error parsing JSON file: %s\n", filename.c_str());
-		fprintf(stderr, "Error: %s\n", e.what());
-		throw std::runtime_error("Invalid JSON format in configuration file: " + filename);
+
+	if (!filename.empty()) {
+		// Load the JSON file and parse it
+		std::ifstream file(filename);
+		if (!file.is_open()) {
+			throw std::runtime_error("Could not open configuration file: " + filename);
+		}
+
+		// Allow comments in the JSON file
+		try {
+			json = json.parse(file, nullptr, false, true);
+		} catch (const nlohmann::json::parse_error& e) {
+			fprintf(stderr, "Error parsing JSON file: %s\n", filename.c_str());
+			fprintf(stderr, "Error: %s\n", e.what());
+			throw std::runtime_error("Invalid JSON format in configuration file: " + filename);
+		}
+	} else {
+		json = nlohmann::json::object();
 	}
 
 	// Parse the JSON data into the Configuration object

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -13,8 +13,9 @@ struct Configuration
 
 	float    max_boot_time = 20.0f; /* Seconds */
 	float    max_req_time  = 8.0f; /* Seconds */
-	uint64_t max_address_space = 0; /* Megabytes */
-	uint64_t max_main_memory = 1024; /* Megabytes */
+	// TODO: tinykvm option for unlimited by default
+	uint64_t max_address_space = 128 * 1024; /* Megabytes */
+	uint64_t max_main_memory = 8 * 1024; /* Megabytes */
 	uint32_t max_req_mem   = 128; /* Megabytes of memory for request VMs */
 	uint32_t limit_req_mem = 128; /* Megabytes to keep after request */
 	uint32_t shared_memory = 0; /* Megabytes */

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -35,9 +35,7 @@ struct Configuration
 	bool     verbose_syscalls = false;
 	bool     verbose_pagetable = false;
 
-	std::vector<std::string> environ {
-		"LC_TYPE=C", "LC_ALL=C", "USER=root"
-	};
+	std::vector<std::string> environ;
 	std::vector<std::string> main_arguments;
 
 	std::vector<tinykvm::VirtualRemapping> vmem_remappings;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -22,7 +22,7 @@ struct Configuration
 	uint32_t heap_address_hint = 0; /* Address hint for the heap */
 	uint64_t hugepage_arena_size = 0; /* Megabytes */
 	uint64_t hugepage_requests_arena = 0; /* Megabytes */
-	bool     executable_heap = false;
+	bool     executable_heap = true;
 	bool     clock_gettime_uses_rdtsc = true;
 	bool     hugepages    = false;
 	bool     split_hugepages = true;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -9,7 +9,7 @@ struct Configuration
 {
 	std::string filename;
 	uint16_t concurrency = 0; /* Request VMs */
-	uint16_t warmup_requests = 250; /* Warmup requests */
+	uint16_t warmup_requests = 0; /* Warmup requests */
 
 	float    max_boot_time = 20.0f; /* Seconds */
 	float    max_req_time  = 8.0f; /* Seconds */

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -28,7 +28,7 @@ struct Configuration
 	bool     split_hugepages = true;
 	bool     transparent_hugepages = false;
 	bool     relocate_fixed_mmap = true;
-	bool     ephemeral = true;
+	bool     ephemeral = false;
 	bool     ephemeral_keep_working_memory = true;
 	bool     verbose = false;
 	bool     verbose_syscalls = false;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -8,7 +8,7 @@
 struct Configuration
 {
 	std::string filename;
-	uint16_t concurrency = 0; /* Request VMs */
+	uint16_t concurrency = 1; /* Request VMs */
 	uint16_t warmup_requests = 0; /* Warmup requests */
 
 	float    max_boot_time = 20.0f; /* Seconds */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,15 +136,15 @@ int main(int argc, char* argv[], char* envp[])
 		}
 		if (args.allow_read || args.allow_write) {
 			config.allowed_paths.push_back(Configuration::VirtualPath {
-				real_path: config.filename,
-				virtual_path: "/proc/self/exe",
-				symlink: true,
+				.real_path = config.filename,
+				.virtual_path = "/proc/self/exe",
+				.symlink = true,
 			});
 			config.allowed_paths.push_back(Configuration::VirtualPath {
-				real_path: "/",
-				virtual_path: "/",
-				writable: args.allow_write,
-				prefix: true,
+				.real_path = "/",
+				.virtual_path = "/",
+				.writable = args.allow_write,
+				.prefix = true,
 			});
 		}
 		// TODO: avoid duplicates

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ static void print_usage(const char* program_name)
 	fprintf(stderr, "  -c, --config <file>      Configuration file\n");
 	fprintf(stderr, "  -t, --threads <num>      Number of request VMs\n");
 	fprintf(stderr, "  -e, --ephemeral          Use ephemeral VMs\n");
-	fprintf(stderr, "  -w, --warmup <num>       Number of warmup requests (default: 250)\n");
+	fprintf(stderr, "  -w, --warmup <num>       Number of warmup requests (default: 0)\n");
 	fprintf(stderr, "  -v, --verbose            Enable verbose output\n");
 	fprintf(stderr, "A configuration file is required in order to be able to host a program.\n");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,6 +136,11 @@ int main(int argc, char* argv[], char* envp[])
 		}
 		if (args.allow_read || args.allow_write) {
 			config.allowed_paths.push_back(Configuration::VirtualPath {
+				real_path: config.filename,
+				virtual_path: "/proc/self/exe",
+				symlink: true,
+			});
+			config.allowed_paths.push_back(Configuration::VirtualPath {
 				real_path: "/",
 				virtual_path: "/",
 				writable: args.allow_write,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,8 +113,10 @@ int main(int argc, char* argv[], char* envp[])
 		// Load the configuration file
 		Configuration config = Configuration::FromJsonFile(args.config_file);
 		// Anything set on the command-line will override the config file
-		if (args.concurrency >= 0) {
+		if (args.concurrency > 0) {
 			config.concurrency = args.concurrency;
+		} else if (args.concurrency == 0) {
+			config.concurrency = std::thread::hardware_concurrency();
 		}
 		if (args.ephemeral) {
 			config.ephemeral = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ struct CommandLineArgs
 };
 static const struct option longopts[] = {
 	{"config", required_argument, nullptr, 'c'},
-	{"concurrency", required_argument, nullptr, 'C'},
+	{"threads", required_argument, nullptr, 't'},
 	{"ephemeral", no_argument, nullptr, 'e'},
 	{"warmup", required_argument, nullptr, 'w'},
 	{"verbose", no_argument, nullptr, 'v'},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,6 +130,7 @@ int main(int argc, char* argv[], char* envp[])
 			}
 			config.filename = args.filename;
 		}
+		// TODO: Should arguments be appended or replaced?
 		for (const auto& arg : args.remaining_args) {
 			config.main_arguments.push_back(arg);
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,9 +113,10 @@ int main(int argc, char* argv[], char* envp[])
 		// Load the configuration file
 		Configuration config = Configuration::FromJsonFile(args.config_file);
 		// Anything set on the command-line will override the config file
-		if (args.concurrency > 0) {
+		if (args.concurrency >= 0) {
 			config.concurrency = args.concurrency;
-		} else if (args.concurrency == 0) {
+		}
+		if (config.concurrency == 0) {
 			config.concurrency = std::thread::hardware_concurrency();
 		}
 		if (args.ephemeral) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ static std::array<std::atomic<uint64_t>, 64> reset_counters;
 
 struct CommandLineArgs
 {
-	unsigned int concurrency = 0;
+	int concurrency = -1;
 	bool ephemeral = false;
 	bool verbose = false;
 	uint16_t warmup_requests = 0;
@@ -32,7 +32,7 @@ static void print_usage(const char* program_name)
 	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "  -p, --program <file>     Program\n");
 	fprintf(stderr, "  -c, --config <file>      Configuration file\n");
-	fprintf(stderr, "  -t, --threads <num>      Number of request VMs\n");
+	fprintf(stderr, "  -t, --threads <num>      Number of request VMs (default: 1)\n");
 	fprintf(stderr, "  -e, --ephemeral          Use ephemeral VMs\n");
 	fprintf(stderr, "  -w, --warmup <num>       Number of warmup requests (default: 0)\n");
 	fprintf(stderr, "  -v, --verbose            Enable verbose output\n");
@@ -53,7 +53,7 @@ static CommandLineArgs parse_command_line(int argc, char* argv[])
 				args.config_file = optarg;
 				break;
 			case 't':
-				args.concurrency = static_cast<unsigned int>(std::stoul(optarg));
+				args.concurrency = static_cast<int>(std::stoul(optarg));
 				break;
 			case 'e':
 				args.ephemeral = true;
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
 		// Load the configuration file
 		Configuration config = Configuration::FromJsonFile(args.config_file);
 		// Anything set on the command-line will override the config file
-		if (args.concurrency > 0) {
+		if (args.concurrency >= 0) {
 			config.concurrency = args.concurrency;
 		}
 		if (args.ephemeral) {

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -334,7 +334,7 @@ void VirtualMachine::init_kvm()
 void VirtualMachine::warmup()
 {
 	// No need to warm up the JIT compiler if we are not using ephemeral VMs
-	if (!config().ephemeral) {
+	if (config().warmup_requests == 0) {
 		return;
 	}
 	printf("Warming up the guest VM (%u requests)...\n", config().warmup_requests);


### PR DESCRIPTION
This PR lets you run:

```sh
DENO_NO_UPDATE_CHECK=1 \
    DENO_V8_FLAGS=--single-threaded,--max-old-space-size=64,--max-semi-space-size=64  \
    bash run.sh --ephemeral --warmup 500 --allow-all \
    --program ~/.deno/bin/deno -- run --allow-all --v8-flags=--single-threaded \
    https://raw.githubusercontent.com/lrowe/react-server-render-benchmark/refs/heads/main/renderer.mjs \
    deno.sock
```

However when doing so this reveals an issue where hitting the instance with a single warmup request leads to 154 freed_fds.

I still need to investigate why this issue is happening. It is not present when running with: 
```sh
bash run.sh --warmup 500 -c deno/config.json -- run --allow-all \
https://raw.githubusercontent.com/lrowe/react-server-render-benchmark/refs/heads/main/renderer.mjs \
deno.sock
```

Both invocations and current main spin on epoll_wait during warmup due to `cpu.machine().threads().suspend_and_yield(SYS_epoll_wait)`. So its' not that.