### PR TITLE
Dockerfile to build kvmserver and example docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/*
+!/ext
+!/src
+!/CMakeLists.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:bookworm-slim AS build
+RUN set -e; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get -y install cmake libc6-dev libjemalloc-dev g++ make; \
+    rm -rf /var/lib/apt/lists/*;
+COPY . /usr/local/src/kvmserver/
+WORKDIR /build
+RUN set -e; \
+    cmake /usr/local/src/kvmserver -DCMAKE_BUILD_TYPE=Release; \
+    make -j 8;
+
+FROM debian:bookworm-slim
+RUN set -e; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get -y install libjemalloc2; \
+    rm -rf /var/lib/apt/lists/*;
+# Convenience for now.
+COPY --from=denoland/deno:bin-2.3.1 /deno /usr/local/bin/
+COPY --from=build /build/kvmserver /usr/local/bin/
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+  backend:
+    build: .
+    command:
+      - /bin/bash
+      - -c
+      - |
+        set -e;
+        rm -f /sock/backend;
+        umask 000;
+        exec kvmserver --allow-all -e -t 2 -w 1000 -p deno -- run --allow-all \
+          'data:,Deno.serve({ path: "/sock/backend" }, () => new Response("hello"))'
+    devices:
+      - /dev/kvm
+    environment:
+      - DENO_NO_UPDATE_CHECK=1
+      - DENO_V8_FLAGS=--predictable,--stress-maglev,--prepare-always-turbofan,--always-turbofan,--always-sparkplug,--max-old-space-size=256,--max-semi-space-size=256
+    group_add:
+      - keep-groups
+    init: true
+    read_only: true
+    tty: true
+    volumes:
+      - sock:/sock
+  varnish:
+    configs:
+      - source: default.vcl
+        target: /etc/varnish/default.vcl
+    depends_on:
+      - backend
+    environment:
+      - VARNISH_HTTP_PORT=8080
+    image: varnish:7.7
+    ports:
+      - "8080:8080"
+    volumes:
+      - sock:/sock
+
+volumes:
+  # Ideally socket volume would be tmpfs but that cannot be shared between containers.
+  sock:
+
+configs:
+  default.vcl:
+    content: |
+      vcl 4.1;
+      backend default {
+        //.host = "backend";
+        //.port = "8000";
+        .path = "/sock/backend";
+      }
+      sub vcl_recv {
+        return (pass);
+      }
+      sub vcl_backend_fetch {
+        set bereq.http.connection = "close";
+        return (fetch);
+      }
+      sub vcl_backend_response {
+          set beresp.uncacheable = true;
+      }


### PR DESCRIPTION
This works but could do with some polishing still.

Something about the way kvmserver handles signals makes ^C not work. Adding `init: true` which runs it under tini at least means `podman-compose down` doesn't pause waiting for SIGTERM to be handled before it SIGKILLs.